### PR TITLE
fix: tcp.Mux error when enabling Flux

### DIFF
--- a/1/debian-10/Dockerfile
+++ b/1/debian-10/Dockerfile
@@ -8,7 +8,7 @@ ENV HOME="/" \
 
 COPY prebuildfs /
 # Install required system packages and dependencies
-RUN install_packages ca-certificates curl gzip libc6 procps tar
+RUN install_packages ca-certificates curl gzip libc6 procps tar netcat
 RUN . /opt/bitnami/scripts/libcomponent.sh && component_unpack "wait-for-port" "1.0.0-1" --checksum 07c4678654b01811f22b5bb65a8d6f8e253abd4524ebb3b78c7d3df042cf23bd
 RUN . /opt/bitnami/scripts/libcomponent.sh && component_unpack "influxdb" "1.8.0-0" --checksum 58455fdb337f33e16b6279196a6846d055a3b8f921c7b6d6d5d78d9f3e66562a
 RUN . /opt/bitnami/scripts/libcomponent.sh && component_unpack "gosu" "1.12.0-0" --checksum 582d501eeb6b338a24f417fededbf14295903d6be55c52d66c52e616c81bcd8c

--- a/1/debian-10/Dockerfile
+++ b/1/debian-10/Dockerfile
@@ -8,7 +8,7 @@ ENV HOME="/" \
 
 COPY prebuildfs /
 # Install required system packages and dependencies
-RUN install_packages ca-certificates curl gzip libc6 procps tar netcat
+RUN install_packages ca-certificates curl gzip libc6 procps tar
 RUN . /opt/bitnami/scripts/libcomponent.sh && component_unpack "wait-for-port" "1.0.0-1" --checksum 07c4678654b01811f22b5bb65a8d6f8e253abd4524ebb3b78c7d3df042cf23bd
 RUN . /opt/bitnami/scripts/libcomponent.sh && component_unpack "influxdb" "1.8.0-0" --checksum 58455fdb337f33e16b6279196a6846d055a3b8f921c7b6d6d5d78d9f3e66562a
 RUN . /opt/bitnami/scripts/libcomponent.sh && component_unpack "gosu" "1.12.0-0" --checksum 582d501eeb6b338a24f417fededbf14295903d6be55c52d66c52e616c81bcd8c

--- a/1/debian-10/rootfs/opt/bitnami/scripts/libinfluxdb.sh
+++ b/1/debian-10/rootfs/opt/bitnami/scripts/libinfluxdb.sh
@@ -40,7 +40,6 @@ export INFLUXDB_DAEMON_USER="influxdb"
 export INFLUXDB_DAEMON_GROUP="influxdb"
 # InfluxDB settings
 export INFLUXDB_REPORTING_DISABLED="${INFLUXDB_REPORTING_DISABLED:-true}"
-export INFLUXDB_HTTP_ENABLED="${INFLUXDB_HTTP_ENABLED:-true}"
 export INFLUXDB_HTTP_PORT_NUMBER="${INFLUXDB_HTTP_PORT_NUMBER:-8086}"
 export INFLUXDB_HTTP_BIND_ADDRESS="${INFLUXDB_HTTP_BIND_ADDRESS:-0.0.0.0:${INFLUXDB_HTTP_PORT_NUMBER}}"
 export INFLUXDB_HTTP_READINESS_TIMEOUT="${INFLUXDB_HTTP_READINESS_TIMEOUT:-60}"
@@ -269,12 +268,8 @@ influxdb_start_bg_noauth() {
     am_i_root && start_command=("gosu" "$INFLUXDB_DAEMON_USER" "${start_command[@]}")
     INFLUXDB_HTTP_HTTPS_ENABLED=false INFLUXDB_HTTP_BIND_ADDRESS="127.0.0.1:${INFLUXDB_HTTP_PORT_NUMBER}" debug_execute "${start_command[@]}" &
     wait-for-port "$INFLUXDB_PORT_NUMBER"
-    if [ "$INFLUXDB_HTTP_ENABLED" = "false" ] ; then
-        warn "InfluxDB HTTP API disabled - this might lead to startup issues."
-    else
-        info "Waiting for HTTP API to be ready..."
-        wait-for-port "$INFLUXDB_HTTP_PORT_NUMBER"
-        wait-for-influxdb
+    wait-for-port "$INFLUXDB_HTTP_PORT_NUMBER"
+    wait-for-influxdb
     fi
 }
 ########################

--- a/1/debian-10/rootfs/opt/bitnami/scripts/libinfluxdb.sh
+++ b/1/debian-10/rootfs/opt/bitnami/scripts/libinfluxdb.sh
@@ -42,6 +42,7 @@ export INFLUXDB_DAEMON_GROUP="influxdb"
 export INFLUXDB_REPORTING_DISABLED="${INFLUXDB_REPORTING_DISABLED:-true}"
 export INFLUXDB_HTTP_PORT_NUMBER="${INFLUXDB_HTTP_PORT_NUMBER:-8086}"
 export INFLUXDB_HTTP_BIND_ADDRESS="${INFLUXDB_HTTP_BIND_ADDRESS:-0.0.0.0:${INFLUXDB_HTTP_PORT_NUMBER}}"
+export INFLUXDB_HTTP_READINESS_TIMEOUT="${INFLUXDB_HTTP_READINESS_TIMEOUT:-60}"
 export INFLUXDB_PORT_NUMBER="${INFLUXDB_PORT_NUMBER:-8088}"
 export INFLUXDB_BIND_ADDRESS="${INFLUXDB_BIND_ADDRESS:-0.0.0.0:${INFLUXDB_PORT_NUMBER}}"
 # Authentication
@@ -305,7 +306,6 @@ influxdb_stop() {
 
 ########################
 # Waits for InfluxDB to be ready
-# Times out after 60 seconds
 # Globals:
 #   INFLUXDB_*
 # Arguments:
@@ -314,7 +314,7 @@ influxdb_stop() {
 #   None
 ########################
 wait-for-influxdb() {
-    curl -SL -I 127.0.0.1:$INFLUXDB_HTTP_PORT_NUMBER/ping?wait_for_leader=60s > /dev/null 2>&1
+    curl -SL -I 127.0.0.1:$INFLUXDB_HTTP_PORT_NUMBER/ping?wait_for_leader=$INFLUXDB_HTTP_READINESS_TIMEOUT\s > /dev/null 2>&1
 }
 
 ########################

--- a/1/debian-10/rootfs/opt/bitnami/scripts/libinfluxdb.sh
+++ b/1/debian-10/rootfs/opt/bitnami/scripts/libinfluxdb.sh
@@ -266,10 +266,8 @@ influxdb_start_bg_noauth() {
     local start_command=("${INFLUXDB_BIN_DIR}/influxd" "-config" "$INFLUXDB_CONF_FILE")
     am_i_root && start_command=("gosu" "$INFLUXDB_DAEMON_USER" "${start_command[@]}")
     INFLUXDB_HTTP_HTTPS_ENABLED=false INFLUXDB_HTTP_BIND_ADDRESS="127.0.0.1:${INFLUXDB_HTTP_PORT_NUMBER}" debug_execute "${start_command[@]}" &
-    while ! nc -zw1 127.0.0.1 $INFLUXDB_HTTP_PORT_NUMBER; do
-        sleep 1;
-    done;
-    curl -SL -I 127.0.0.1:$INFLUXDB_HTTP_PORT_NUMBER/ping?wait_for_leader=60s > /dev/null 2>&1
+    wait-for-port "$INFLUXDB_HTTP_PORT_NUMBER"
+    wait-for-influxdb
 }
 
 ########################
@@ -303,6 +301,20 @@ influxdb_stop() {
     ! is_influxdb_running && return
     pkill --full --signal TERM "$INFLUXDB_BASE_DIR"
     wait-for-port --state free "$INFLUXDB_PORT_NUMBER"
+}
+
+########################
+# Waits for InfluxDB to be ready
+# Times out after 60 seconds
+# Globals:
+#   INFLUXDB_*
+# Arguments:
+#   None
+# Returns:
+#   None
+########################
+wait-for-influxdb() {
+    curl -SL -I 127.0.0.1:$INFLUXDB_HTTP_PORT_NUMBER/ping?wait_for_leader=60s > /dev/null 2>&1
 }
 
 ########################

--- a/1/debian-10/rootfs/opt/bitnami/scripts/libinfluxdb.sh
+++ b/1/debian-10/rootfs/opt/bitnami/scripts/libinfluxdb.sh
@@ -40,6 +40,7 @@ export INFLUXDB_DAEMON_USER="influxdb"
 export INFLUXDB_DAEMON_GROUP="influxdb"
 # InfluxDB settings
 export INFLUXDB_REPORTING_DISABLED="${INFLUXDB_REPORTING_DISABLED:-true}"
+export INFLUXDB_HTTP_ENABLED="${INFLUXDB_HTTP_ENABLED:-true}"
 export INFLUXDB_HTTP_PORT_NUMBER="${INFLUXDB_HTTP_PORT_NUMBER:-8086}"
 export INFLUXDB_HTTP_BIND_ADDRESS="${INFLUXDB_HTTP_BIND_ADDRESS:-0.0.0.0:${INFLUXDB_HTTP_PORT_NUMBER}}"
 export INFLUXDB_HTTP_READINESS_TIMEOUT="${INFLUXDB_HTTP_READINESS_TIMEOUT:-60}"
@@ -267,10 +268,15 @@ influxdb_start_bg_noauth() {
     local start_command=("${INFLUXDB_BIN_DIR}/influxd" "-config" "$INFLUXDB_CONF_FILE")
     am_i_root && start_command=("gosu" "$INFLUXDB_DAEMON_USER" "${start_command[@]}")
     INFLUXDB_HTTP_HTTPS_ENABLED=false INFLUXDB_HTTP_BIND_ADDRESS="127.0.0.1:${INFLUXDB_HTTP_PORT_NUMBER}" debug_execute "${start_command[@]}" &
-    wait-for-port "$INFLUXDB_HTTP_PORT_NUMBER"
-    wait-for-influxdb
+    wait-for-port "$INFLUXDB_PORT_NUMBER"
+    if [ "$INFLUXDB_HTTP_ENABLED" = "false" ] ; then
+        warn "InfluxDB HTTP API disabled - this might lead to startup issues."
+    else
+        info "Waiting for HTTP API to be ready..."
+        wait-for-port "$INFLUXDB_HTTP_PORT_NUMBER"
+        wait-for-influxdb
+    fi
 }
-
 ########################
 # Check if InfluxDB is running
 # Globals:

--- a/1/debian-10/rootfs/opt/bitnami/scripts/libinfluxdb.sh
+++ b/1/debian-10/rootfs/opt/bitnami/scripts/libinfluxdb.sh
@@ -266,7 +266,10 @@ influxdb_start_bg_noauth() {
     local start_command=("${INFLUXDB_BIN_DIR}/influxd" "-config" "$INFLUXDB_CONF_FILE")
     am_i_root && start_command=("gosu" "$INFLUXDB_DAEMON_USER" "${start_command[@]}")
     INFLUXDB_HTTP_HTTPS_ENABLED=false INFLUXDB_HTTP_BIND_ADDRESS="127.0.0.1:${INFLUXDB_HTTP_PORT_NUMBER}" debug_execute "${start_command[@]}" &
-    wait-for-port "$INFLUXDB_PORT_NUMBER"
+    while ! nc -zw1 127.0.0.1 $INFLUXDB_HTTP_PORT_NUMBER; do
+        sleep 1;
+    done;
+    curl -SL -I 127.0.0.1:$INFLUXDB_HTTP_PORT_NUMBER/ping?wait_for_leader=60s > /dev/null 2>&1
 }
 
 ########################


### PR DESCRIPTION
Closes #1

**Description of the change**

- ~Adds `netcat` package to image~
- ~Removes `wait-for-port` causing the issue, replaced with...~
- New logic to check database readiness
   - ~Use the right port in `wait-for-port`~
   - ~`netcat` to check if the port accepts connections~
   - Additional `wait-for-port` for HTTP
   - `curl` logic to check if the database is ready (see https://github.com/influxdata/influxdb/issues/4595#issuecomment-151958860)
- Added warning when `INFLUXDB_HTTP_ENABLED=false`

**Benefits**

- Allows the use of Flux, the next-generation query language developed by InfluxDB.

**Possible drawbacks**

- None

**Applicable issues**

- #1 

**Additional information**
```bash
 docker run --rm -e INFLUXDB_ADMIN_USER_PASSWORD=password -e INFLUXDB_HTTP_FLUX_ENABLED=true -e BITNAMI_DEBUG=true bitnami/influxdb:1.8.0-debian-10-r23 # errors out
 docker run --rm -e INFLUXDB_ADMIN_USER_PASSWORD=password -e INFLUXDB_HTTP_FLUX_ENABLED=true -e BITNAMI_DEBUG=true lelithium/influxdb:fix-flux # works

 docker run --rm -e INFLUXDB_ADMIN_USER_PASSWORD=password -e INFLUXDB_HTTP_FLUX_ENABLED=true -e BITNAMI_DEBUG=true -p 8086:8086 lelithium/influxdb:fix-flux
influx  # works
influx -type=flux  # works
```
---
Edited 2020-05-26:
- Striked out the addition of `netcat` and removal of `wait-for-port`
- Mentioned wrong `wait-for-port` port
---
Edited 2020-06-01
- Striked out the erroneous wrong port mention
- Mentioned new warning