### PR TITLE
fix: custom script initialization check

### DIFF
--- a/2/debian-11/rootfs/opt/bitnami/scripts/libinfluxdb.sh
+++ b/2/debian-11/rootfs/opt/bitnami/scripts/libinfluxdb.sh
@@ -534,7 +534,7 @@ influxdb_initialize() {
 #   None
 #########################
 influxdb_custom_init_scripts() {
-    if [[ -n $(find "${INFLUXDB_INITSCRIPTS_DIR}/" -type f -regex ".*\.\(sh\|txt\)") ]] && [[ ! -f "${INFLUXDB_INITSCRIPTS_DIR}/.user_scripts_initialized" ]]; then
+    if [[ -n $(find "${INFLUXDB_INITSCRIPTS_DIR}/" -type f -regex ".*\.\(sh\|txt\)") ]] && [[ ! -f "${INFLUXDB_VOLUME_DIR}/.user_scripts_initialized" ]]; then
         info "Loading user's custom files from ${INFLUXDB_INITSCRIPTS_DIR} ..."
         local -r tmp_file="/tmp/filelist"
         if ! is_influxdb_running; then


### PR DESCRIPTION
**Description of the change**

Fixes checking of custom script initialization. The current version will run the init scripts anytime the docker container is started.

**Benefits**

custom scripts will not be run over and over again (and failing due to that) once initialized

**Possible drawbacks**

No

**Applicable issues**

**Additional information**
